### PR TITLE
Travis-CI doesn't have Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,10 @@
 language: c++
+sudo: required
 dist: trusty
-matrix:
-  include:
-  - #dist: trusty
-    compiler: gcc
-    os: linux
-    sudo: required
-  - #dist: trusty
-    compiler: clang
-    os: linux
-    sudo: required
-  - dist: xenial
-    compiler: gcc
-    os: linux
-    sudo: required
-  - dist: xenial
-    compiler: clang
-    os: linux
-    sudo: required
+
+compiler:
+  - gcc
+  - clang
 
 before_script:
   - sudo apt-get update -qq


### PR DESCRIPTION
Travis-CI fails to fail with an unknown dist, and Xenial is currently unknown. Currently the fallback seems to be Trusty. Hence this simplification of the control file.