### PR TITLE
GCC 7 requires this #include.

### DIFF
--- a/src/fic_decoder.cpp
+++ b/src/fic_decoder.cpp
@@ -18,6 +18,8 @@
 
 #include "fic_decoder.h"
 
+#include <vector>
+
 
 const SERVICE SERVICE::no_service(-1);
 

--- a/src/fic_decoder.cpp
+++ b/src/fic_decoder.cpp
@@ -18,8 +18,6 @@
 
 #include "fic_decoder.h"
 
-#include <vector>
-
 
 const SERVICE SERVICE::no_service(-1);
 

--- a/src/fic_decoder.h
+++ b/src/fic_decoder.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <map>
 #include <set>
+#include <vector>
 
 #include "tools.h"
 


### PR DESCRIPTION
Compiling on Fedora Rawhide using GCC 7.0.1 via CMake with Ninja backend, this #include is neede to get a compilation.